### PR TITLE
feat(BREAKING): handle Windows app execution aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,21 @@ const pathToCurl = await which("curl", {
   statSync(filePath: string): { isFile: boolean } {
     // implement this
   },
+  // lstat/readLink are used as a fallback on Windows when stat throws
+  // with EACCES, to resolve Windows Store app execution aliases (and
+  // user-created symlinks pointing at them)
+  async lstat(filePath: string): Promise<{ isFile: boolean; isSymlink: boolean }> {
+    // implement this
+  },
+  lstatSync(filePath: string): { isFile: boolean; isSymlink: boolean } {
+    // implement this
+  },
+  async readLink(filePath: string): Promise<string> {
+    // implement this
+  },
+  readLinkSync(filePath: string): string {
+    // implement this
+  },
   env(key: string): string | undefined {
     // implement getting an environment variable
   },

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ const pathToCurl = await which("curl", {
   // lstat/readLink are used as a fallback on Windows when stat throws
   // with EACCES, to resolve Windows Store app execution aliases (and
   // user-created symlinks pointing at them)
-  async lstat(filePath: string): Promise<{ isFile: boolean; isSymlink: boolean }> {
+  async lstat(
+    filePath: string,
+  ): Promise<{ isFile: boolean; isSymlink: boolean }> {
     // implement this
   },
   lstatSync(filePath: string): { isFile: boolean; isSymlink: boolean } {

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -1,5 +1,5 @@
 import { test } from "node:test";
-import { equal } from "node:assert/strict";
+import { equal, rejects, throws } from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
@@ -87,6 +87,28 @@ test("should get existent path when providing a custom system", async () => {
           throw new Error("Not found.");
         }
       },
+      lstat(p) {
+        p = p.replace(/\//g, "\\");
+        if (p === "C:\\test\\home\\asdfasdfasdfasdfasdf.EXE") {
+          return Promise.resolve({ isFile: true, isSymlink: false });
+        } else {
+          return Promise.reject(new Error("Not found."));
+        }
+      },
+      lstatSync(p) {
+        p = p.replace(/\//g, "\\");
+        if (p === "C:\\test\\home\\asdfasdfasdfasdfasdf.EXE") {
+          return { isFile: true, isSymlink: false };
+        } else {
+          throw new Error("Not found.");
+        }
+      },
+      readLink() {
+        return Promise.reject(new Error("not a symlink"));
+      },
+      readLinkSync() {
+        throw new Error("not a symlink");
+      },
       isWindows: true,
     };
     let result = await which("asdfasdfasdfasdfasdf", environment);
@@ -147,6 +169,155 @@ test("should return undefined for a path-like command that doesn't exist", async
   const missing = path.join(os.tmpdir(), "definitely-missing-binary-xyz");
   equal(await which(missing), undefined);
   equal(whichSync(missing), undefined);
+});
+
+const eaccesErr = Object.assign(new Error("EACCES"), { code: "EACCES" });
+const enoentErr = Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+
+test("should fall back via lstat when stat fails with EACCES (Windows app exec alias)", async () => {
+  // Simulates a Windows Store app execution alias: stat fails (EACCES on
+  // the reparse point), but lstat reports the entry as a regular file.
+  await runTest(async (which) => {
+    const target = "C:\\WindowsApps\\winget.EXE";
+    const environment: Environment = {
+      env(key) {
+        if (key === "PATH") return "C:\\WindowsApps";
+        if (key === "PATHEXT") return ".EXE";
+        return undefined;
+      },
+      stat() {
+        return Promise.reject(eaccesErr);
+      },
+      statSync() {
+        throw eaccesErr;
+      },
+      lstat(p) {
+        return p.replace(/\//g, "\\") === target
+          ? Promise.resolve({ isFile: true, isSymlink: false })
+          : Promise.reject(enoentErr);
+      },
+      lstatSync(p) {
+        if (p.replace(/\//g, "\\") === target) {
+          return { isFile: true, isSymlink: false };
+        }
+        throw enoentErr;
+      },
+      readLink() {
+        return Promise.reject(new Error("not a symlink"));
+      },
+      readLinkSync() {
+        throw new Error("not a symlink");
+      },
+      isWindows: true,
+    };
+    const result = (await which("winget", environment))?.replace(/\//g, "\\");
+    equal(result, target);
+  });
+});
+
+test("should walk the symlink chain when stat fails with EACCES", async () => {
+  // A symlink in PATH whose target stat can't traverse. The library should
+  // follow it via lstat+readLink until reaching a regular file.
+  await runTest(async (which) => {
+    const link = "C:\\bin\\my-winget.EXE";
+    const finalTarget = "C:\\Apps\\winget.exe";
+    const environment: Environment = {
+      env(key) {
+        if (key === "PATH") return "C:\\bin";
+        if (key === "PATHEXT") return ".EXE";
+        return undefined;
+      },
+      stat() {
+        return Promise.reject(eaccesErr);
+      },
+      statSync() {
+        throw eaccesErr;
+      },
+      lstat(p) {
+        const n = p.replace(/\//g, "\\");
+        if (n === link) {
+          return Promise.resolve({ isFile: false, isSymlink: true });
+        }
+        if (n === finalTarget) {
+          return Promise.resolve({ isFile: true, isSymlink: false });
+        }
+        return Promise.reject(enoentErr);
+      },
+      lstatSync(p) {
+        const n = p.replace(/\//g, "\\");
+        if (n === link) return { isFile: false, isSymlink: true };
+        if (n === finalTarget) return { isFile: true, isSymlink: false };
+        throw enoentErr;
+      },
+      readLink(p) {
+        if (p.replace(/\//g, "\\") === link) {
+          return Promise.resolve(finalTarget);
+        }
+        return Promise.reject(new Error("not a symlink"));
+      },
+      readLinkSync(p) {
+        if (p.replace(/\//g, "\\") === link) return finalTarget;
+        throw new Error("not a symlink");
+      },
+      isWindows: true,
+    };
+    const result = (await which("my-winget", environment))?.replace(
+      /\//g,
+      "\\",
+    );
+    equal(result, link);
+  });
+});
+
+test("should rethrow Deno permission errors from stat", async () => {
+  // Simulates a Deno runtime permission denial: a PermissionDenied-style
+  // error without code "EACCES". Must NOT be silently swallowed.
+  class PermissionDenied extends Error {
+    constructor(msg: string) {
+      super(msg);
+      this.name = "PermissionDenied";
+    }
+  }
+  const denoPermErr = new PermissionDenied("Requires read access");
+  const environment: Environment = {
+    env(key) {
+      if (key === "PATH") return "/usr/bin";
+      return undefined;
+    },
+    stat() {
+      return Promise.reject(denoPermErr);
+    },
+    statSync() {
+      throw denoPermErr;
+    },
+    lstat() {
+      return Promise.reject(new Error("should not be called"));
+    },
+    lstatSync() {
+      throw new Error("should not be called");
+    },
+    readLink() {
+      return Promise.reject(new Error("should not be called"));
+    },
+    readLinkSync() {
+      throw new Error("should not be called");
+    },
+    isWindows: false,
+  };
+  // Stub Deno.errors.PermissionDenied for the instanceof check.
+  // deno-lint-ignore no-explicit-any
+  const deno = (globalThis as any).Deno;
+  if (deno != null) {
+    const prevPD = deno.errors?.PermissionDenied;
+    deno.errors = deno.errors ?? {};
+    deno.errors.PermissionDenied = PermissionDenied;
+    try {
+      await rejects(which("anything", environment), PermissionDenied);
+      throws(() => whichSync("anything", environment), PermissionDenied);
+    } finally {
+      deno.errors.PermissionDenied = prevPD;
+    }
+  }
 });
 
 test("should get the path to a symlink", async () => {

--- a/mod.ts
+++ b/mod.ts
@@ -7,6 +7,23 @@ export interface Environment {
    * following symlinks.
    */
   statSync(filePath: string): { isFile: boolean };
+  /** Resolves the file info for the specified path without following symlinks.
+   *
+   * On Windows, the library falls back to this when {@link Environment.stat}
+   * throws with EACCES — needed to resolve Windows Store app execution aliases,
+   * whose reparse points cause stat to fail with EACCES but lstat to succeed.
+   * If the entry is itself a symlink, the library walks the chain via
+   * {@link Environment.readLink} until it reaches a file (handles the case of
+   * a user-created symlink pointing at a Store app alias).
+   */
+  lstat(filePath: string): Promise<{ isFile: boolean; isSymlink: boolean }>;
+  /** Synchronous variant of {@link Environment.lstat}. */
+  lstatSync(filePath: string): { isFile: boolean; isSymlink: boolean };
+  /** Reads the literal target of a symlink. Used to walk symlink chains
+   * when stat can't traverse them. */
+  readLink(filePath: string): Promise<string>;
+  /** Synchronous variant of {@link Environment.readLink}. */
+  readLinkSync(filePath: string): string;
   /** Whether the current operating system is Windows. */
   isWindows: boolean;
   /** Optional method for requesting broader permissions for a folder
@@ -54,6 +71,38 @@ export class RealEnvironment implements Environment {
     return { isFile: info.isFile() };
   }
 
+  async lstat(
+    path: string,
+  ): Promise<{ isFile: boolean; isSymlink: boolean }> {
+    if (denoGlobal?.lstat) {
+      return await denoGlobal.lstat(path);
+    }
+    const info = await getNodeFs().promises.lstat(path);
+    return { isFile: info.isFile(), isSymlink: info.isSymbolicLink() };
+  }
+
+  lstatSync(path: string): { isFile: boolean; isSymlink: boolean } {
+    if (denoGlobal?.lstatSync) {
+      return denoGlobal.lstatSync(path);
+    }
+    const info = getNodeFs().lstatSync(path);
+    return { isFile: info.isFile(), isSymlink: info.isSymbolicLink() };
+  }
+
+  async readLink(path: string): Promise<string> {
+    if (denoGlobal?.readLink) {
+      return await denoGlobal.readLink(path);
+    }
+    return await getNodeFs().promises.readlink(path);
+  }
+
+  readLinkSync(path: string): string {
+    if (denoGlobal?.readLinkSync) {
+      return denoGlobal.readLinkSync(path);
+    }
+    return getNodeFs().readlinkSync(path);
+  }
+
   get isWindows(): boolean {
     if (denoGlobal?.build?.os) {
       return denoGlobal.build.os === "windows";
@@ -71,7 +120,8 @@ export class RealEnvironment implements Environment {
  */
 export async function which(
   command: string,
-  environment: Omit<Environment, "statSync"> = new RealEnvironment(),
+  environment: Omit<Environment, "statSync" | "lstatSync" | "readLinkSync"> =
+    new RealEnvironment(),
 ): Promise<string | undefined> {
   if (commandHasPathSeparator(command, environment.isWindows)) {
     if (await pathMatches(environment, command)) {
@@ -115,18 +165,54 @@ export async function which(
 }
 
 async function pathMatches(
-  environment: Omit<Environment, "statSync">,
+  environment: Omit<Environment, "statSync" | "lstatSync" | "readLinkSync">,
   path: string,
 ): Promise<boolean> {
   try {
-    const result = await environment.stat(path);
-    return result.isFile;
-  } catch (err) {
-    if (isPermissionDeniedError(err)) {
-      throw err;
+    return (await environment.stat(path)).isFile;
+  } catch (statErr) {
+    if (isDenoPermissionDeniedError(statErr)) {
+      throw statErr;
+    }
+    // on Windows, EACCES on stat is the signal for Store app execution
+    // aliases and similar reparse points stat can't traverse — fall back
+    // to lstat, and walk via readLink if the entry is itself a symlink
+    if (environment.isWindows && isEaccesError(statErr)) {
+      return await followSymlinkChain(environment, path);
     }
     return false;
   }
+}
+
+async function followSymlinkChain(
+  environment: Pick<Environment, "lstat" | "readLink">,
+  path: string,
+): Promise<boolean> {
+  let current = path;
+  for (let hops = 0; hops < 40; hops++) {
+    let info;
+    try {
+      info = await environment.lstat(current);
+    } catch (err) {
+      if (isDenoPermissionDeniedError(err)) {
+        throw err;
+      }
+      return false;
+    }
+    if (info.isFile) return true;
+    if (!info.isSymlink) return false;
+    let target;
+    try {
+      target = await environment.readLink(current);
+    } catch (err) {
+      if (isDenoPermissionDeniedError(err)) {
+        throw err;
+      }
+      return false;
+    }
+    current = resolveLinkTarget(current, target);
+  }
+  return false;
 }
 
 /** Finds the path to the specified command synchronously.
@@ -135,7 +221,8 @@ async function pathMatches(
  */
 export function whichSync(
   command: string,
-  environment: Omit<Environment, "stat"> = new RealEnvironment(),
+  environment: Omit<Environment, "stat" | "lstat" | "readLink"> =
+    new RealEnvironment(),
 ): string | undefined {
   if (commandHasPathSeparator(command, environment.isWindows)) {
     if (pathMatchesSync(environment, command)) {
@@ -179,21 +266,78 @@ export function whichSync(
 }
 
 function pathMatchesSync(
-  environment: Omit<Environment, "stat">,
+  environment: Omit<Environment, "stat" | "lstat" | "readLink">,
   path: string,
 ): boolean {
   try {
-    const result = environment.statSync(path);
-    return result.isFile;
-  } catch (err) {
-    if (isPermissionDeniedError(err)) {
-      throw err;
+    return environment.statSync(path).isFile;
+  } catch (statErr) {
+    if (isDenoPermissionDeniedError(statErr)) {
+      throw statErr;
+    }
+    // see comment in pathMatches
+    if (environment.isWindows && isEaccesError(statErr)) {
+      return followSymlinkChainSync(environment, path);
     }
     return false;
   }
 }
 
-function isPermissionDeniedError(err: unknown): boolean {
+function followSymlinkChainSync(
+  environment: Pick<Environment, "lstatSync" | "readLinkSync">,
+  path: string,
+): boolean {
+  let current = path;
+  for (let hops = 0; hops < 40; hops++) {
+    let info;
+    try {
+      info = environment.lstatSync(current);
+    } catch (err) {
+      if (isDenoPermissionDeniedError(err)) {
+        throw err;
+      }
+      return false;
+    }
+    if (info.isFile) return true;
+    if (!info.isSymlink) return false;
+    let target;
+    try {
+      target = environment.readLinkSync(current);
+    } catch (err) {
+      if (isDenoPermissionDeniedError(err)) {
+        throw err;
+      }
+      return false;
+    }
+    current = resolveLinkTarget(current, target);
+  }
+  return false;
+}
+
+function resolveLinkTarget(linkPath: string, target: string): string {
+  if (isAbsolutePath(target)) {
+    return target;
+  }
+  const sepIdx = Math.max(
+    linkPath.lastIndexOf("/"),
+    linkPath.lastIndexOf("\\"),
+  );
+  const dir = sepIdx >= 0 ? linkPath.slice(0, sepIdx + 1) : "";
+  return dir + target;
+}
+
+function isAbsolutePath(p: string): boolean {
+  if (p.startsWith("/") || p.startsWith("\\")) return true;
+  // windows drive-rooted (e.g. "C:\foo" or "C:/foo")
+  return /^[A-Za-z]:[\\/]/.test(p);
+}
+
+function isEaccesError(err: unknown): boolean {
+  return err != null && typeof err === "object" && "code" in err &&
+    (err as { code?: unknown }).code === "EACCES";
+}
+
+function isDenoPermissionDeniedError(err: unknown): boolean {
   const permissionDeniedError = denoGlobal?.errors?.PermissionDenied;
   return permissionDeniedError != null && err instanceof permissionDeniedError;
 }
@@ -206,7 +350,7 @@ interface SystemInfo {
 
 function getSystemInfo(
   command: string,
-  environment: Omit<Environment, "stat" | "statSync">,
+  environment: Pick<Environment, "isWindows" | "env">,
 ): SystemInfo | undefined {
   const isWindows = environment.isWindows;
   const path = environment.env("PATH");


### PR DESCRIPTION
The fact I have to do this shows they messed up.

For https://github.com/dsherret/dax/issues/133